### PR TITLE
Update link MODEL_REPOSITORY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER Konstantin Baierer <konstantin.baierer@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 # ENV MODEL_REPOSITORY http://www.tmbdev.net/ocropy/
-ENV MODEL_REPOSITORY http://www-test.bib.uni-mannheim.de/infolis/ocropy
+ENV MODEL_REPOSITORY http://data.bib.uni-mannheim.de/ocr-models/zip/ocropy/
 
 RUN apt-get update && \
   apt-get -y install --no-install-recommends git ca-certificates curl && \


### PR DESCRIPTION
Currently I have the following error:

```
$ ./run-ocropy rpred test.png

gzip: stdin: not in gzip format
INFO:
INFO:  ########## /ocropy/ocropus-rpred test.png
INFO:
INFO:  #inputs1
# loading object /usr/local/share/ocropus/en-default.pyrnn.gz
Traceback (most recent call last):
  File "/ocropy/ocropus-rpred", line 109, in <module>
    network = ocrolib.load_object(args.model,verbose=1)
  File "/ocropy/ocrolib/common.py", line 513, in load_object
    return unpickler.load()
EOFError
```
